### PR TITLE
Fix MSVC deprecation warning

### DIFF
--- a/Modelica_DeviceDrivers/Resources/Include/MDDTCPIPSocketServer.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDTCPIPSocketServer.h
@@ -21,7 +21,6 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include <winsock2.h>
 #include <ws2tcpip.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -159,7 +158,7 @@ DllExport void * MDD_TCPIPServer_Constructor(int serverport, int maxClients, int
         MDD_TCPIPServer_Destructor(tcpip); // Explicit call, because it won't be called automatically by Modelica, since object not constructed, yet.
         ModelicaFormatError("MDDTCPIPSocketServer.h:%d: given server port number %d higher than allowable for IPv4 (maximum 65535)", __LINE__, serverport);
     }
-  _snprintf(serverport_str, 9, "%d", serverport);
+    _snprintf(serverport_str, 9, "%d", serverport);
     iResult = getaddrinfo(NULL, serverport_str, &hints, &result);
     if ( iResult != 0 ) {
         MDD_TCPIPServer_Destructor(tcpip); // Explicit call, because it won't be called automatically by Modelica, since object not constructed, yet.

--- a/Modelica_DeviceDrivers/Resources/Include/MDDUDPSocket.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDUDPSocket.h
@@ -27,7 +27,7 @@
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 
-#include <winsock2.h>
+#include <ws2tcpip.h>
 #include "../src/include/CompatibilityDefs.h"
 
 #pragma comment( lib, "Ws2_32.lib" )
@@ -186,8 +186,8 @@ DllExport void * MDD_udpConstructor(int port, int bufferSize, int useReceiveThre
 
 DllExport void MDD_udpDestructor(void * p_udp) {
     MDDUDPSocket * udp = (MDDUDPSocket *) p_udp;
-    int rc;
     if (udp) {
+        int rc;
         udp->receiving = 0;
         rc = shutdown(udp->SocketID, 2);
         if (rc == SOCKET_ERROR) {
@@ -212,13 +212,19 @@ DllExport void MDD_udpDestructor(void * p_udp) {
 DllExport void MDD_udpSend(void * p_udp, const char * ipAddress, int port,
                            const char * data, int dataSize) {
     MDDUDPSocket * udp = (MDDUDPSocket *) p_udp;
-    int rc;
     if (udp) {
+        int rc;
         SOCKADDR_IN addr;
         addr.sin_family=AF_INET;
         addr.sin_port=htons((u_short)port);
-        addr.sin_addr.s_addr=inet_addr(ipAddress);
-        rc = sendto(udp->SocketID,data,dataSize,0,(SOCKADDR*)&addr,sizeof(SOCKADDR_IN));
+        rc = inet_pton(AF_INET, ipAddress, &addr.sin_addr.s_addr);
+        if (rc == 0) {
+            ModelicaFormatError("MDDUDPSocket.h: inet_pton failed for \"%s\"\n", ipAddress);
+        }
+        else if (rc == -1) {
+            ModelicaFormatError("MDDUDPSocket.h: inet_pton failed with error code: %d\n", WSAGetLastError());
+        }
+        rc = sendto(udp->SocketID, data, dataSize, 0, (SOCKADDR*)&addr, sizeof(SOCKADDR_IN));
         if (rc == SOCKET_ERROR) {
             ModelicaFormatError("MDDUDPSocket.h: sendto failed with error code: %d\n", WSAGetLastError());
         }
@@ -236,13 +242,13 @@ DllExport void MDD_udpSendP(void * p_udp, const char * ipAddress, int port,
 
 DllExport const char * MDD_udpRead(void * p_udp) {
     MDDUDPSocket * udp = (MDDUDPSocket *) p_udp;
-    SOCKADDR remoteAddr;
-    int remoteAddrLen;
-    char* udpBuf;
 
     if (udp && (!udp->useReceiveThread || (udp->useReceiveThread && udp->hThread))) {
+        char* udpBuf;
 
         if (!udp->useReceiveThread) {
+            SOCKADDR remoteAddr;
+            int remoteAddrLen;
             remoteAddrLen = sizeof(SOCKADDR);
             udp->nReceivedBytes = recvfrom(udp->SocketID, udp->receiveBuffer, udp->bufferSize,0,&remoteAddr,&remoteAddrLen);
             if(udp->nReceivedBytes==SOCKET_ERROR) {
@@ -270,13 +276,13 @@ DllExport const char * MDD_udpRead(void * p_udp) {
 
 DllExport void MDD_udpReadP2(void * p_udp, void* p_package, int* nReceivedBytes, int* nRecvbufOverwrites) {
     MDDUDPSocket * udp = (MDDUDPSocket *) p_udp;
-    SOCKADDR remoteAddr;
-    int remoteAddrLen;
-    int rc;
 
     if (udp && (!udp->useReceiveThread || (udp->useReceiveThread && udp->hThread))) {
+        int rc;
 
         if (!udp->useReceiveThread) {
+            SOCKADDR remoteAddr;
+            int remoteAddrLen;
             remoteAddrLen = sizeof(SOCKADDR);
             udp->nReceivedBytes = recvfrom(udp->SocketID, udp->receiveBuffer, udp->bufferSize,0,&remoteAddr,&remoteAddrLen);
             if(udp->nReceivedBytes==SOCKET_ERROR) {


### PR DESCRIPTION
Fix warning MDDUDPSocket.h(220): warning C4996: 'inet_addr': Use inet_pton() or InetPton() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings

Tested that it still compiles with VS2010