### PR TITLE
Option `cleanup` for shared memory (closes #339)

### DIFF
--- a/Modelica_DeviceDrivers/Blocks/Communication.mo
+++ b/Modelica_DeviceDrivers/Blocks/Communication.mo
@@ -1,4 +1,4 @@
-within Modelica_DeviceDrivers.Blocks;
+﻿within Modelica_DeviceDrivers.Blocks;
 package Communication "Blocks for communication devices such as network, CAN, shared memory, etc."
     extends Modelica.Icons.Package;
   block SharedMemoryRead
@@ -19,6 +19,8 @@ package Communication "Blocks for communication devices such as network, CAN, sh
       "Buffer size of shared memory partition in bytes (if not deduced automatically)"
       annotation(Dialog(enable=not autoBufferSize, group="Shared memory partition"));
     parameter String memoryID="sharedMemory" "ID of the shared memory buffer" annotation(Dialog(group="Shared memory partition"));
+    parameter Boolean cleanup = true "true, unlink shared memory at process termination, otherwise no unlink ⇒ 'memoryID' can still be opened (Linux specific, otherwise no effect)"
+      annotation(Dialog(group="Shared memory partition"), choices(checkBox=true));
     Interfaces.PackageOut pkgOut(pkg = SerialPackager(if autoBufferSize then bufferSize else userBufferSize), dummy(start=0, fixed=true))
       annotation (Placement(
           transformation(
@@ -26,7 +28,7 @@ package Communication "Blocks for communication devices such as network, CAN, sh
           rotation=90,
           origin={108,0})));
   protected
-    SharedMemory sm = SharedMemory(memoryID, bufferSize);
+    SharedMemory sm = SharedMemory(memoryID, bufferSize, cleanup);
     Integer bufferSize;
   equation
     when initial() then
@@ -63,13 +65,15 @@ provided by the parameter <b>memoryID</b>. If the shared memory partition does n
       "Buffer size of shared memory partition in bytes (if not deduced automatically)"
       annotation(Dialog(enable=not autoBufferSize, group="Shared memory partition"));
     parameter String memoryID="sharedMemory" "ID of the shared memory buffer" annotation(Dialog(group="Shared memory partition"));
+    parameter Boolean cleanup = true "true, unlink shared memory at process termination, otherwise no unlink ⇒ 'memoryID' can still be opened (Linux specific, otherwise no effect)"
+      annotation(Dialog(group="Shared memory partition"), choices(checkBox=true));
     Interfaces.PackageIn pkgIn annotation (Placement(
           transformation(
           extent={{-20,20},{20,-20}},
           rotation=90,
           origin={-108,0})));
   protected
-    SharedMemory sm = SharedMemory(memoryID, if autoBufferSize then bufferSize else userBufferSize);
+    SharedMemory sm = SharedMemory(memoryID, if autoBufferSize then bufferSize else userBufferSize, cleanup);
     Integer bufferSize;
     Real dummy(start=0, fixed=true);
   equation

--- a/Modelica_DeviceDrivers/ClockedBlocks/Communication.mo
+++ b/Modelica_DeviceDrivers/ClockedBlocks/Communication.mo
@@ -1,4 +1,4 @@
-within Modelica_DeviceDrivers.ClockedBlocks;
+﻿within Modelica_DeviceDrivers.ClockedBlocks;
 package Communication
   extends Modelica.Icons.Package;
   model SharedMemoryRead "A block for reading data from a shared memory buffer"
@@ -18,6 +18,8 @@ package Communication
       "Buffer size of shared memory partition in bytes (if not deduced automatically)"
       annotation(Dialog(enable=not autoBufferSize, group="Shared memory partition"));
     parameter String memoryID="sharedMemory" "ID of the shared memory buffer" annotation(Dialog(group="Shared memory partition"));
+    parameter Boolean cleanup = true "true, unlink shared memory at process termination, otherwise no unlink ⇒ 'memoryID' can still be opened (Linux specific, otherwise no effect)"
+      annotation(Dialog(group="Shared memory partition"), choices(checkBox=true));
 
     Interfaces.PackageOut pkgOut annotation (Placement(
           transformation(
@@ -77,6 +79,8 @@ provided by the parameter <b>memoryID</b>. If the shared memory partition does n
       "Buffer size of shared memory partition in bytes (if not deduced automatically)"
       annotation(Dialog(enable=not autoBufferSize, group="Shared memory partition"));
     parameter String memoryID="sharedMemory" "ID of the shared memory buffer" annotation(Dialog(group="Shared memory partition"));
+    parameter Boolean cleanup = true "true, unlink shared memory at process termination, otherwise no unlink ⇒ 'memoryID' can still be opened (Linux specific, otherwise no effect)"
+      annotation(Dialog(group="Shared memory partition"), choices(checkBox=true));
 
     Interfaces.PackageIn pkgIn annotation (Placement(
           transformation(

--- a/Modelica_DeviceDrivers/Communication/SharedMemory.mo
+++ b/Modelica_DeviceDrivers/Communication/SharedMemory.mo
@@ -1,4 +1,4 @@
-within Modelica_DeviceDrivers.Communication;
+﻿within Modelica_DeviceDrivers.Communication;
 class SharedMemory
   "A driver for shared memory access for inter-process communication."
 extends ExternalObject;
@@ -8,8 +8,9 @@ extends ExternalObject;
     import Modelica_DeviceDrivers.Communication.SharedMemory;
     input String memoryName;
     input Integer bufferSize = 16* 1024;
+    input Boolean cleanup = true "true, unlink shared memory at process termination, otherwise no unlink ⇒ 'memoryID' can still be opened (Linux specific, otherwise no effect)";
     output SharedMemory sm;
-    external "C" sm =  MDD_SharedMemoryConstructor(memoryName,bufferSize)
+    external "C" sm =  MDD_SharedMemoryConstructor(memoryName,bufferSize,cleanup)
     annotation(Include = "#include \"MDDSharedMemory.h\"",
            Library = {"rt", "pthread"},
            __iti_dll = "ITI_MDD.dll",

--- a/Modelica_DeviceDrivers/Resources/Include/MDDSharedMemory.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDSharedMemory.h
@@ -194,9 +194,14 @@ void * MDD_SharedMemoryConstructor(const char * name, int bufSize, int cleanup) 
         }
 
         ModelicaFormatMessage("Open shared memory object '%s' for r/w\n", smb->shmname);
-        smb->shmdes = shm_open(smb->shmname, O_CREAT|O_RDWR|O_TRUNC, 0644);
+        smb->shmdes = shm_open(smb->shmname, O_RDWR, 0644);
         if ( smb->shmdes == -1 ) {
-            ModelicaFormatError("MDDSharedMemory.h: shm_open failure (%s)", strerror(errno));
+            ModelicaFormatMessage("Open shared memory object '%s' for r/w failed (%s) => Create new shared memory object\n", smb->shmname, strerror(errno));
+            // usleep(100);
+            smb->shmdes = shm_open(smb->shmname, O_CREAT|O_RDWR|O_TRUNC, 0644);
+            if ( smb->shmdes == -1 ) {
+                ModelicaFormatError("MDDSharedMemory.h: shm_open(%s, O_CREAT|O_RDWR|O_TRUNC, 0644) failure (%s)", smb->shmname, strerror(errno));
+            }
         }
 
         /* 'truncate' shared memory object to needed size

--- a/Modelica_DeviceDrivers/Resources/Include/MDDSharedMemory.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDSharedMemory.h
@@ -35,7 +35,8 @@ typedef struct {
     HANDLE hSemaphore;
 } MDDSharedMemory;
 
-DllExport void* MDD_SharedMemoryConstructor(const char * name, int bufSize) {
+/** Argument 'cleanup' has no effect, only needed for signature compatibility with linux version */
+DllExport void* MDD_SharedMemoryConstructor(const char * name, int bufSize, int cleanup) {
     MDDSharedMemory * smb = (MDDSharedMemory *)malloc(sizeof(MDDSharedMemory));
     char semName[MAX_PATH];
 
@@ -150,8 +151,7 @@ DllExport void MDD_SharedMemoryWriteP(void * p_smb, void* p_package, int len) {
 
 typedef struct MDDMmap_struct MDDMmap;
 
-/** External object structure keeping track of persistent data
- */
+/** External object structure keeping track of persistent data */
 struct MDDMmap_struct {
     char shmname[30]; /**< name of memory partition */
     char semname[33]; /**< name of semaphore derived from shmname */
@@ -159,12 +159,14 @@ struct MDDMmap_struct {
     int shmdes;  /**< shared memory file descriptor */
     caddr_t shmptr;  /**< pointer to shared memory partition */
     sem_t *semdes; /**< address of semaphore */
+    int cleanup; /**< if true, unlink shared memory in destructor, otherwise don't unlink (=> 'memoryID' can still be opened after process termination) */
 };
 
-void * MDD_SharedMemoryConstructor(const char * name, int bufSize) {
+void * MDD_SharedMemoryConstructor(const char * name, int bufSize, int cleanup) {
     int sval;
     MDDMmap* smb = (MDDMmap*) malloc(sizeof(MDDMmap));
     smb->shm_size = bufSize;
+    smb->cleanup = cleanup;
     strncpy(smb->shmname, name, (30 - 1));
     strcpy(smb->semname, smb->shmname);
     strcat(smb->semname, "sem");
@@ -240,32 +242,34 @@ void MDD_SharedMemoryDestructor(void * p_smb) {
         ModelicaFormatError("MDDSharedMemory.h: sem_close failed (%s)\n", strerror(errno));
     }
 
-    ModelicaFormatMessage("Unlinking shared memory object '%s' and semaphore '%s' ...\n", smb->shmname, smb->semname);
-    /* Delete the shared memory object */
-    ret = shm_unlink(smb->shmname);
-    if(ret) {
-        if (errno == ENOENT) {
-            ModelicaFormatMessage("Shared memory object '%s' seems to be already removed (possibly by remote process)\n", smb->shmname);
+    if (smb->cleanup) {
+        ModelicaFormatMessage("Unlinking shared memory object '%s' and semaphore '%s' ...\n", smb->shmname, smb->semname);
+        /* Delete the shared memory object */
+        ret = shm_unlink(smb->shmname);
+        if(ret) {
+            if (errno == ENOENT) {
+                ModelicaFormatMessage("Shared memory object '%s' seems to be already removed (possibly by remote process)\n", smb->shmname);
+            }
+            else {
+                ModelicaFormatError("MDDSharedMemory.h: shm_unlink failed (%s)\n", strerror(errno));
+            }
         }
         else {
-            ModelicaFormatError("MDDSharedMemory.h: shm_unlink failed (%s)\n", strerror(errno));
+            ModelicaFormatMessage("Shared memory object '%s' successfully unlinked\n", smb->shmname);
         }
-    }
-    else {
-        ModelicaFormatMessage("Shared memory object '%s' successfully unlinked\n", smb->shmname);
-    }
-    /* Unlink the semaphore */
-    ret = sem_unlink(smb->semname);
-    if(ret) {
-        if (errno == ENOENT) {
-            ModelicaFormatMessage("Semaphore '%s' seems to be already removed (possibly by remote process)\n", smb->semname);
+        /* Unlink the semaphore */
+        ret = sem_unlink(smb->semname);
+        if(ret) {
+            if (errno == ENOENT) {
+                ModelicaFormatMessage("Semaphore '%s' seems to be already removed (possibly by remote process)\n", smb->semname);
+            }
+            else {
+                ModelicaFormatError("MDDSharedMemory.h: sem_unlink failed (%s)\n", strerror(errno));
+            }
         }
         else {
-            ModelicaFormatError("MDDSharedMemory.h: sem_unlink failed (%s)\n", strerror(errno));
+            ModelicaFormatMessage("Semaphore '%s' successfully unlinked\n", smb->semname);
         }
-    }
-    else {
-        ModelicaFormatMessage("Semaphore '%s' successfully unlinked\n", smb->semname);
     }
 
     free(smb);

--- a/Modelica_DeviceDrivers/Resources/test/Communication/test_MDDSharedMemory.c
+++ b/Modelica_DeviceDrivers/Resources/test/Communication/test_MDDSharedMemory.c
@@ -32,6 +32,7 @@
 */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include "../../Include/MDDSharedMemory.h"
 
 #define M_LENGTH (80)
@@ -45,13 +46,13 @@ int main(void) {
 
     printf("Testing MDDSharedMemory\n");
 
-    smb1 = MDD_SharedMemoryConstructor(semname, M_LENGTH);
+    smb1 = MDD_SharedMemoryConstructor(semname, M_LENGTH, true);
     if (smb1 == 0) {
         perror("smb1 == NULL\n");
         exit(1);
     }
 
-    smb2 = MDD_SharedMemoryConstructor(semname, M_LENGTH);
+    smb2 = MDD_SharedMemoryConstructor(semname, M_LENGTH, true);
     if (smb2 == 0) {
         MDD_SharedMemoryDestructor(smb1);
         perror("smb2 == NULL\n");


### PR DESCRIPTION
Linux specific option for not unlinking shared memory partition
at process termination (no effect on Windows).