### PR TITLE
Add more explanation to UDP examples

### DIFF
--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackagerBitPack_UDP.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackagerBitPack_UDP.mo
@@ -93,5 +93,11 @@ equation
 <p>
 In particular this model demonstrates how integer values can be packed and unpacked at bit level using the <a href=\"modelica://Modelica_DeviceDrivers.Blocks.Packaging.SerialPackager.PackUnsignedInteger\"> <code>PackUnsignedInteger</code></a> and <a href=\"modelica://Modelica_DeviceDrivers.Blocks.Packaging.SerialPackager.UnpackUnsignedInteger\"><code>UnpackUnsignedInteger</code></a> blocks.
 </p>
+<p>This example sends data to address 127.0.0.1, which is a special-purpose 
+IPv4 address and is called the localhost or loopback address.
+When you have to transfer data to another computer you have to use in uDPSend 
+that computer's IP. You've also to set the port number of the remote computer you want to send to.</p>
+<p>When you want to receive data from another computer, you have set in uDPReceive 
+the actual port number of the local computer you a willing to receive data to.</p><p>
 </html>"));
 end TestSerialPackagerBitPack_UDP;

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDP.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDP.mo
@@ -67,6 +67,12 @@ The <code>uDPSend</code> block sends to the local port 10002. The <code>uDPRecei
 <p>
 <b>Note:</b> There is no causality between the <code>uDPSend</code> block and the <code>uDPReceive</code> block. Therefore the execution order of the blocks is not determined. Additionally, the <code>uDPReceive</code> block starts an own receiving thread, so that the time the data was received is not equal to the time the external function within the <code>uDPReceive</code> block was called. This indeterminism may also show up in the plots.
 </p>
+<p>This example sends data to address 127.0.0.1, which is a special-purpose 
+IPv4 address and is called the localhost or loopback address.
+When you have to transfer data to another computer you have to use in uDPSend 
+that computer's IP. You've also to set the port number of the remote computer you want to send to.</p>
+<p>When you want to receive data from another computer, you have set in uDPReceive 
+the actual port number of the local computer you a willing to receive data to.</p><p>
 </html>"),
     experiment(
       StopTime=5,

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDPAutoBufferSize.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDPAutoBufferSize.mo
@@ -73,5 +73,11 @@ The <code>uDPSend</code> block sends to the local port 10002. The <code>uDPRecei
 <p>
 <b>Note:</b> There is no causality between the <code>uDPSend</code> block and the <code>uDPReceive</code> block. Therefore the execution order of the blocks is not determined. Additionally, the <code>uDPReceive</code> block starts an own receiving thread, so that the time the data was received is not equal to the time the external function within the <code>uDPReceive</code> block was called. This indeterminism may also show up in the plots.
 </p>
+<p>This example sends data to address 127.0.0.1, which is a special-purpose 
+IPv4 address and is called the localhost or loopback address.
+When you have to transfer data to another computer you have to use in uDPSend 
+that computer's IP. You've also to set the port number of the remote computer you want to send to.</p>
+<p>When you want to receive data from another computer, you have set in uDPReceive 
+the actual port number of the local computer you a willing to receive data to.</p><p>
 </html>"));
 end TestSerialPackager_UDPAutoBufferSize;

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDPExternalTrigger.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDPExternalTrigger.mo
@@ -82,6 +82,12 @@ The <code>uDPSend</code> block sends to the local port 10002. The <code>uDPRecei
 <p>
 <b>Note:</b> There is no causality between the <code>uDPSend</code> block and the <code>uDPReceive</code> block. Therefore the execution order of the blocks is not determined. Additionally, the <code>uDPReceive</code> block starts an own receiving thread, so that the time the data was received is not equal to the time the external function within the <code>uDPReceive</code> block was called. This indeterminism may also show up in the plots.
 </p>
+<p>This example sends data to address 127.0.0.1, which is a special-purpose 
+IPv4 address and is called the localhost or loopback address.
+When you have to transfer data to another computer you have to use in uDPSend 
+that computer's IP. You've also to set the port number of the remote computer you want to send to.</p>
+<p>When you want to receive data from another computer, you have set in uDPReceive 
+the actual port number of the local computer you a willing to receive data to.</p><p>
 </html>"),
     experiment(
       StopTime=5,


### PR DESCRIPTION
I've just added a few rows of comments to the blocks UDP examples.
this helps people like me, previously unaware o UDP way to operate, to understand how to use UDP communication through Modelica.
I successfully communicated via UDP between a computer running Dymola and another one running LabView.