### PR TITLE
Update text annotations to not use deprecated features

### DIFF
--- a/Modelica_DeviceDrivers/Blocks/Communication.mo
+++ b/Modelica_DeviceDrivers/Blocks/Communication.mo
@@ -1376,12 +1376,12 @@ See <a href=\"modelica://Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackag
     Icon(graphics={
           Text(
             extent={{-100,-72},{100,-96}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="maxClients: %maxClients"),
           Text(extent={{-150,142},{150,102}}, textString="%name"),
           Text(
             extent={{-100,96},{100,72}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="port: %port")}),
       Documentation(info="<html>
 <p>
@@ -1459,7 +1459,7 @@ TCP/IP server configuration block. This block is supposed to be used as an inner
               textString="%name"),
           Text(
             extent={{-100,100},{100,40}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="%clientIndex")}),
                                      Documentation(info="<html>
 <p>Supports receiving of TCP/IP packets stemming from a client that connected to our server.</p>
@@ -1540,7 +1540,7 @@ TCP/IP server configuration block. This block is supposed to be used as an inner
               textString="%name"),
           Text(
             extent={{-100,100},{100,40}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="%clientIndex")}),
                                      Documentation(info="<html>
 <p>Supports sending of TCP/IP packets to a client that connected to our server.</p>

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestHardwareIOComedi.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestHardwareIOComedi.mo
@@ -68,7 +68,7 @@ equation
       color={0,0,127}));
   annotation (Diagram(graphics={Text(
           extent={{-108,106},{108,76}},
-          lineColor={0,0,255},
+          textColor={0,0,255},
           textString="Example for USB-DUX D
 Assuming input channels are electrical connected to corresponding output channels we should read what we wrote")}),
       experiment(StopTime=5.0),

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_LCM.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_LCM.mo
@@ -91,7 +91,7 @@ sudo route add -net 224.0.0.0 netmask 240.0.0.0 dev lo
       StartTime=0),
     Diagram(graphics={        Text(
           extent={{-94,88},{96,60}},
-          lineColor={0,0,255},
+          textColor={0,0,255},
           textString="Please have a look at the documentation
 before trying this example.")}));
 end TestSerialPackager_LCM;

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_SocketCAN.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_SocketCAN.mo
@@ -75,7 +75,7 @@ annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}),
                     graphics={Text(
           extent={{-94,92},{96,64}},
-          lineColor={0,0,255},
+          textColor={0,0,255},
           textString="Please see documentation for system requirements
 for using the Linux Socket CAN bus interface!")}),
                                experiment(StopTime=1.0), Documentation(info="<html>

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_SoftingCAN.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_SoftingCAN.mo
@@ -118,7 +118,7 @@ annotation (Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,
             -100},{100,100}}),
                     graphics={Text(
           extent={{-94,92},{96,64}},
-          lineColor={0,0,255},
+          textColor={0,0,255},
           textString="Please see documentation for system requirements
 for using the Softing CAN bus interface!")}),
                                experiment(StopTime=1.0), Documentation(info="<html>

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_String.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_String.mo
@@ -56,7 +56,7 @@ equation
   annotation (Diagram(coordinateSystem(preserveAspectRatio=false,extent={{-100,
             -100},{100,100}}), graphics={Text(
           extent={{-82,84},{82,68}},
-          lineColor={0,0,255},
+          textColor={0,0,255},
           textString=
               "Please have look at the documentation to this model before executing.")}),
                                           experiment(StopTime=5.0),

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_TCPIPServer.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_TCPIPServer.mo
@@ -86,6 +86,6 @@ a client is provided as C code test program
     Diagram(graphics={
         Text(
           extent={{-68,102},{66,84}},
-          lineColor={238,46,47},
+          textColor={238,46,47},
           textString="Needs a connecting client to give meaningful results")}));
 end TestSerialPackager_TCPIPServer;

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_TCPIPServerMultipleClients.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_TCPIPServerMultipleClients.mo
@@ -93,13 +93,13 @@ connect(addInteger[1:2].pkgOut[1], tCPIPSend[1:2].pkgIn)
     Diagram(graphics={
         Text(
           extent={{-100,-70},{98,-90}},
-          lineColor={28,108,200},
+          textColor={28,108,200},
           textString="Example uses array components.
 Notice that it was necessary to modify the Modelica code that resulted from graphical editing, by textually adapting statements, namely:
 AddInteger addInteger[2](each n=3, each nu=1)
 connect(addInteger[1:2].pkgOut[1], tCPIPSend[1:2].pkgIn)"),
         Text(
           extent={{-80,100},{80,80}},
-          lineColor={238,46,47},
+          textColor={238,46,47},
           textString="Needs connecting clients to give meaningful results")}));
 end TestSerialPackager_TCPIPServerMultipleClients;

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDPWithoutReceiveThread.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_UDPWithoutReceiveThread.mo
@@ -85,6 +85,6 @@ The <code>uDPSend</code> block sends to the local port 10002. The <code>uDPRecei
       StartTime=0),
     Diagram(graphics={Text(
           extent={{2,70},{82,64}},
-          lineColor={28,108,200},
+          textColor={28,108,200},
           textString="Ensure that send is called before receive is called")}));
 end TestSerialPackager_UDPWithoutReceiveThread;

--- a/Modelica_DeviceDrivers/Blocks/InputDevices.mo
+++ b/Modelica_DeviceDrivers/Blocks/InputDevices.mo
@@ -137,9 +137,7 @@ package InputDevices "Blocks for input devices, such as keyboard, gamecontroller
             fillPattern=FillPattern.Solid),
           Text(
             extent={{100,-12},{164,-38}},
-            lineColor={95,95,95},
-            fillColor={95,95,95},
-            fillPattern=FillPattern.Solid,
+            textColor={95,95,95},
             textString="keyState"),
           Polygon(
             points={{-80,80},{80,80},{60,78},{-60,78},{-80,80}},
@@ -149,10 +147,7 @@ package InputDevices "Blocks for input devices, such as keyboard, gamecontroller
             fillPattern=FillPattern.Solid),
           Text(
             extent={{-100,20},{100,-20}},
-            lineColor={0,0,255},
-            pattern=LinePattern.None,
-            fillColor={236,236,236},
-            fillPattern=FillPattern.Solid,
+            textColor={0,0,255},
             textString="%keyCode")}),
       preferredView="info",
       Documentation(info="<html> This block reads data from the keyboard. The monitored key is selected via the parameter <b>keyCode</b>.
@@ -367,15 +362,11 @@ package InputDevices "Blocks for input devices, such as keyboard, gamecontroller
           Line(points={{0,60},{100,60}}, color={255,0,255}),
           Text(
             extent={{100,-72},{164,-98}},
-            lineColor={95,95,95},
-            fillColor={95,95,95},
-            fillPattern=FillPattern.Solid,
+            textColor={95,95,95},
             textString="space"),
           Text(
             extent={{100,-12},{164,-38}},
-            lineColor={95,95,95},
-            fillColor={95,95,95},
-            fillPattern=FillPattern.Solid,
+            textColor={95,95,95},
             textString="return")}),
               preferredView="info",Documentation(info="<html> This block reads data from the keyboard. The arrow keys, space and return are monitored.
                                        Note, that keystrokes will not be captured and the focused window will process them.

--- a/Modelica_DeviceDrivers/Blocks/OperatingSystem.mo
+++ b/Modelica_DeviceDrivers/Blocks/OperatingSystem.mo
@@ -43,12 +43,12 @@ package OperatingSystem "Blocks for miscellaneous OS API related facilities, e.g
       final startTime=startTime) if sampled and enable
       annotation (Placement(transformation(extent={{-60,-60},{-40,-40}})));
 
-    Modelica.Blocks.Sources.RealExpression dummyOutputs[4](y={0,0,0,0}) if
-                                                                 not enable
+    Modelica.Blocks.Sources.RealExpression dummyOutputs[4](y={0,0,0,0})
+                                                              if not enable
       annotation (Placement(transformation(extent={{-20,70},{0,90}})));
-    Modelica.Blocks.Routing.Multiplex4 mux_continuous if     not sampled and enable
+    Modelica.Blocks.Routing.Multiplex4 mux_continuous     if not sampled and enable
       annotation (Placement(transformation(extent={{-20,20},{0,40}})));
-    Modelica.Blocks.Routing.Multiplex4 mux_sampled if     sampled and enable
+    Modelica.Blocks.Routing.Multiplex4 mux_sampled     if sampled and enable
       annotation (Placement(transformation(extent={{-20,-60},{0,-40}})));
     Modelica.Blocks.Routing.DeMultiplex4 demux
       annotation (Placement(transformation(extent={{20,-10},{40,10}})));
@@ -95,10 +95,7 @@ package OperatingSystem "Blocks for miscellaneous OS API related facilities, e.g
             lineColor={175,175,175}), Text(
             visible=not enable,
             extent={{-100,-112},{100,-136}},
-            lineColor={135,135,135},
-            pattern=LinePattern.Dash,
-            fillColor={255,255,255},
-            fillPattern=FillPattern.Solid,
+            textColor={135,135,135},
             textString="Deactivated"),
           Bitmap(extent={{-60,-60},{60,60}}, fileName="modelica://Modelica_DeviceDrivers/Resources/Images/Icons/clock.png"),
           Text(extent={{-150,142},{150,102}}, textString="%name"),
@@ -150,7 +147,7 @@ package OperatingSystem "Blocks for miscellaneous OS API related facilities, e.g
 <p>Typically, this block will be used together with the <a href=\"modelica://Modelica_DeviceDrivers.Blocks.OperatingSystem.RealtimeSynchronize\">RealtimeSynchronize</a> block for improving the real-time performance.</p>
 </html>"), Icon(graphics={
           Text(extent={{-100,20},{100,-20}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="%priority"),
           Text(extent={{-150,142},{150,102}}, textString="%name")}));
   end ProcessPriority;
@@ -192,17 +189,15 @@ package OperatingSystem "Blocks for miscellaneous OS API related facilities, e.g
             pattern=LinePattern.Dash),
           Text(
             extent={{-100,62},{-72,46}},
-            lineColor={135,135,135},
-            pattern=LinePattern.Dash,
+            textColor={135,135,135},
             textString="max"),
           Text(
             extent={{-100,-44},{-72,-60}},
-            lineColor={135,135,135},
-            pattern=LinePattern.Dash,
+            textColor={135,135,135},
             textString="min"),
           Text(
             extent={{-100,140},{100,100}},
-            lineColor={0,0,255},
+            textColor={0,0,255},
             textString="%name")}),
       Documentation(info="<html>
 <p>Uses the <code>rand()</code>function from the C standard library for creating pseudo-random numbers. The computers real-time clock is used to obtain seed values for the sequence of pseudo-random numbers.</p>
@@ -363,7 +358,7 @@ package OperatingSystem "Blocks for miscellaneous OS API related facilities, e.g
       annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
               Text(
               extent={{-86,32},{88,-30}},
-              lineColor={28,108,200},
+              textColor={28,108,200},
               textString="Continuous")}),                            Diagram(
             coordinateSystem(preserveAspectRatio=false)));
     end RealtimeSynchronize_Continuous;
@@ -386,7 +381,7 @@ package OperatingSystem "Blocks for miscellaneous OS API related facilities, e.g
       annotation (Icon(coordinateSystem(preserveAspectRatio=false), graphics={
               Text(
               extent={{-88,28},{92,-30}},
-              lineColor={28,108,200},
+              textColor={28,108,200},
               textString="Sampled")}),                               Diagram(
             coordinateSystem(preserveAspectRatio=false)));
     end RealtimeSynchronize_Sampled;

--- a/Modelica_DeviceDrivers/Blocks/Packaging/SerialPackager.mo
+++ b/Modelica_DeviceDrivers/Blocks/Packaging/SerialPackager.mo
@@ -212,7 +212,7 @@ package SerialPackager "Blocks for constructing packages"
        annotation (Dialog(enable = not useBackwardPropagatedBufferSize, tab="Advanced", group="Buffer size settings"));
     Interfaces.PackageOut pkgOut(pkg = SerialPackager(if useBackwardPropagatedBufferSize then bufferSize else userBufferSize), dummy(start=0, fixed=true))
       annotation (Placement(transformation(extent={{-20,-128},{20,-88}})));
-    Modelica.Blocks.Interfaces.BooleanInput trigger if                    enableExternalTrigger
+    Modelica.Blocks.Interfaces.BooleanInput trigger                    if enableExternalTrigger
       annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   protected
     Modelica.Blocks.Interfaces.BooleanInput internalTrigger;
@@ -298,7 +298,7 @@ and one Integer value is added, serialized and finally sent using UDP.
     annotation (Icon(graphics={
           Text(
             extent={{-118,40},{-38,-40}},
-            lineColor={255,0,255},
+            textColor={255,0,255},
             textString="B"),
           Polygon(
             points={{6,0},{-14,20},{-14,10},{-44,10},{-44,-10},{-14,-10},{-14,
@@ -341,7 +341,7 @@ and one Integer value is added, serialized and finally sent using UDP.
             textString="%n * int32"),
           Text(
             extent={{-120,40},{-40,-40}},
-            lineColor={255,127,0},
+            textColor={255,127,0},
             textString="I"),
           Polygon(
             points={{6,0},{-14,20},{-14,10},{-44,10},{-44,-10},{-14,-10},{-14,
@@ -384,9 +384,7 @@ and one Integer value is added, serialized and finally sent using UDP.
             textString="%n * double"),
           Text(
             extent={{-112,40},{-32,-40}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={0,0,255},
+            textColor={0,0,255},
             textString="R"),
           Polygon(
             points={{8,0},{-12,20},{-12,10},{-42,10},{-42,-10},{-12,-10},{-12,
@@ -429,9 +427,7 @@ and one Integer value is added, serialized and finally sent using UDP.
             textString="%n * float"),
           Text(
             extent={{-112,40},{-32,-40}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={0,0,255},
+            textColor={0,0,255},
             textString="R"),
           Bitmap(extent={{-40,-22},{20,22}}, fileName=
                 "modelica://Modelica_DeviceDrivers/Resources/Images/Icons/Real2FloatArrow.png")}));
@@ -463,7 +459,7 @@ and one Integer value is added, serialized and finally sent using UDP.
     annotation (Icon(graphics={
           Text(
             extent={{-112,40},{-32,-40}},
-            lineColor={255,127,0},
+            textColor={255,127,0},
             textString="S"),
           Polygon(
             points={{14,0},{-6,20},{-6,10},{-36,10},{-36,-10},{-6,-10},{-6,-20},
@@ -473,7 +469,7 @@ and one Integer value is added, serialized and finally sent using UDP.
             fillPattern=FillPattern.Solid),
           Text(
             extent={{-100,-40},{100,-80}},
-            lineColor={255,127,0},
+            textColor={255,127,0},
             textString="%data")}));
   end AddString;
 
@@ -512,7 +508,7 @@ and one Integer value is added, serialized and finally sent using UDP.
     annotation (Icon(graphics={
           Text(
             extent={{30,40},{110,-40}},
-            lineColor={255,0,255},
+            textColor={255,0,255},
             textString="B"),
           Polygon(
             points={{44,0},{24,20},{24,10},{-6,10},{-6,-10},{24,-10},{24,-20},{
@@ -555,7 +551,7 @@ and one Integer value is added, serialized and finally sent using UDP.
     annotation (Icon(graphics={
           Text(
             extent={{40,40},{120,-40}},
-            lineColor={255,127,0},
+            textColor={255,127,0},
             textString="I"),
           Polygon(
             points={{44,0},{24,20},{24,10},{-6,10},{-6,-10},{24,-10},{24,-20},{
@@ -599,9 +595,7 @@ and one Integer value is added, serialized and finally sent using UDP.
     annotation (Icon(graphics={
           Text(
             extent={{30,40},{110,-40}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={0,0,255},
+            textColor={0,0,255},
             textString="R"),
           Polygon(
             points={{44,0},{24,20},{24,10},{-6,10},{-6,-10},{24,-10},{24,-20},{
@@ -648,9 +642,7 @@ and one Integer value is added, serialized and finally sent using UDP.
                      graphics={
           Text(
             extent={{30,40},{110,-40}},
-            lineColor={0,0,255},
-            fillPattern=FillPattern.Solid,
-            fillColor={0,0,255},
+            textColor={0,0,255},
             textString="R"),
           Text(
             extent={{-100,-50},{100,-90}},
@@ -688,7 +680,7 @@ and one Integer value is added, serialized and finally sent using UDP.
     annotation (Icon(graphics={
           Text(
             extent={{38,40},{118,-40}},
-            lineColor={255,127,0},
+            textColor={255,127,0},
             textString="S"),
           Polygon(
             points={{42,0},{22,20},{22,10},{-8,10},{-8,-10},{22,-10},{22,-20},{
@@ -728,12 +720,10 @@ and one Integer value is added, serialized and finally sent using UDP.
       Icon(graphics={
           Text(
             extent={{-120,40},{-40,-40}},
-            lineColor={255,127,0},
+            textColor={255,127,0},
             textString="I"),
           Text(
             extent={{-100,-50},{100,-90}},
-            fillColor={0,0,127},
-            fillPattern=FillPattern.Solid,
             textString="%bitOffset + %width bits"),
           Bitmap(extent={{-56,-20},{8,19}}, fileName=
                 "Modelica://Modelica_DeviceDrivers/Resources/Images/Icons/Int2BitArrow.png")}),
@@ -793,12 +783,10 @@ Value of bit                   : (0  0  0  0  0  0  1  1)  (.  .   .  .  .  .  0
                 "Modelica://Modelica_DeviceDrivers/Resources/Images/Icons/Bit2IntArrow.png"),
           Text(
             extent={{-100,-50},{100,-90}},
-            fillColor={0,0,127},
-            fillPattern=FillPattern.Solid,
             textString="%bitOffset + %width bits"),
           Text(
             extent={{40,40},{120,-40}},
-            lineColor={255,127,0},
+            textColor={255,127,0},
             textString="I")}),
       Documentation(info="<html>
 <p>The block allows to unpack unsigned integer values on bit level. The number of bits used for decoding is set by parameter <code>width</code>. The parameter <code>bitOffset</code> allows to specify the bit at which the decoding starts <b>relative</b> to the preceding block. </p>
@@ -856,7 +844,6 @@ Value of bit                   :                               0  1  .  .  .  . 
             fillColor={255,255,255}),
           Text(
             extent={{-100,-40},{100,-80}},
-            fillPattern=FillPattern.Solid,
             textString="Reset")}));
   end ResetPointer;
 annotation (preferredView="info", Documentation(info="<html>

--- a/Modelica_DeviceDrivers/ClockedBlocks/Examples.mo
+++ b/Modelica_DeviceDrivers/ClockedBlocks/Examples.mo
@@ -505,7 +505,7 @@ The <code>uDPSend</code> block sends to the local port 10002. The <code>uDPRecei
 </html>"),
       Diagram(graphics={Text(
             extent={{-98,-74},{-18,-80}},
-            lineColor={28,108,200},
+            textColor={28,108,200},
             textString="Ensure that send is called before receive is called")}));
   end TestSerialPackager_UDPWithoutReceiveThread;
 
@@ -1103,7 +1103,7 @@ Basic example of using a keyboard as input device.
               -100},{100,100}}),
                         graphics={Text(
             extent={{-108,106},{108,76}},
-            lineColor={0,0,255},
+            textColor={0,0,255},
             textString="Example for USB-DUX D
 Assuming input channels are electrical connected to corresponding output channels we should read what we wrote")}),
         experiment(StopTime=5.0),

--- a/Modelica_DeviceDrivers/ClockedBlocks/InputDevices.mo
+++ b/Modelica_DeviceDrivers/ClockedBlocks/InputDevices.mo
@@ -139,9 +139,7 @@ package InputDevices
             fillPattern=FillPattern.Solid),
           Text(
             extent={{100,-12},{164,-38}},
-            lineColor={95,95,95},
-            fillColor={95,95,95},
-            fillPattern=FillPattern.Solid,
+            textColor={95,95,95},
             textString="keyState"),
           Polygon(
             points={{-80,80},{80,80},{60,78},{-60,78},{-80,80}},
@@ -151,10 +149,7 @@ package InputDevices
             fillPattern=FillPattern.Solid),
           Text(
             extent={{-100,20},{100,-20}},
-            lineColor={0,0,255},
-            pattern=LinePattern.None,
-            fillColor={236,236,236},
-            fillPattern=FillPattern.Solid,
+            textColor={0,0,255},
             textString="%keyCode")}),
               preferredView="info",Documentation(info="<html>
 <p>This block reads data from the keyboard. The monitored key is selected via the parameter <b>keyCode</b>. Note, that keystrokes will not be captured and the focused window will process them.</p>
@@ -365,15 +360,11 @@ package InputDevices
           Line(points={{0,60},{100,60}}, color={255,0,255}),
           Text(
             extent={{100,-72},{164,-98}},
-            lineColor={95,95,95},
-            fillColor={95,95,95},
-            fillPattern=FillPattern.Solid,
+            textColor={95,95,95},
             textString="space"),
           Text(
             extent={{100,-12},{164,-38}},
-            lineColor={95,95,95},
-            fillColor={95,95,95},
-            fillPattern=FillPattern.Solid,
+            textColor={95,95,95},
             textString="return")}),
               preferredView="info",Documentation(info="<html>
 <p>This block reads data from the keyboard. The arrow keys, space and return are monitored. Note, that keystrokes will not be captured and the focused window will process them.</p>

--- a/Modelica_DeviceDrivers/ClockedBlocks/OperatingSystem.mo
+++ b/Modelica_DeviceDrivers/ClockedBlocks/OperatingSystem.mo
@@ -148,17 +148,15 @@ package OperatingSystem
             pattern=LinePattern.Dash),
           Text(
             extent={{-100,62},{-72,46}},
-            lineColor={135,135,135},
-            pattern=LinePattern.Dash,
+            textColor={135,135,135},
             textString="max"),
           Text(
             extent={{-100,-44},{-72,-60}},
-            lineColor={135,135,135},
-            pattern=LinePattern.Dash,
+            textColor={135,135,135},
             textString="min"),
           Text(
             extent={{-100,140},{100,100}},
-            lineColor={0,0,255},
+            textColor={0,0,255},
             textString="%name")}),
       Documentation(info="<html>
 <p>Uses the <code>rand()</code>function from the C standard library for creating pseudo-random numbers. The computers real-time clock is used to obtain seed values for the sequence of pseudo-random numbers.</p>

--- a/Modelica_DeviceDrivers/ClockedBlocks/Packaging.mo
+++ b/Modelica_DeviceDrivers/ClockedBlocks/Packaging.mo
@@ -255,7 +255,7 @@ package Packaging
       annotation (Icon(graphics={
             Text(
               extent={{-118,40},{-38,-40}},
-              lineColor={255,0,255},
+              textColor={255,0,255},
               textString="B"),
             Polygon(
               points={{6,0},{-14,20},{-14,10},{-44,10},{-44,-10},{-14,-10},{-14,
@@ -293,7 +293,7 @@ package Packaging
               textString="%n * int32"),
             Text(
               extent={{-120,40},{-40,-40}},
-              lineColor={255,127,0},
+              textColor={255,127,0},
               textString="I"),
             Polygon(
               points={{6,0},{-14,20},{-14,10},{-44,10},{-44,-10},{-14,-10},{-14,
@@ -328,9 +328,7 @@ package Packaging
               textString="%n * double"),
             Text(
               extent={{-112,40},{-32,-40}},
-              lineColor={0,0,255},
-              fillPattern=FillPattern.Solid,
-              fillColor={0,0,255},
+              textColor={0,0,255},
               textString="R"),
             Polygon(
               points={{8,0},{-12,20},{-12,10},{-42,10},{-42,-10},{-12,-10},{-12,
@@ -366,9 +364,7 @@ package Packaging
               textString="%n * float"),
             Text(
               extent={{-112,40},{-32,-40}},
-              lineColor={0,0,255},
-              fillPattern=FillPattern.Solid,
-              fillColor={0,0,255},
+              textColor={0,0,255},
               textString="R"),
             Bitmap(extent={{-42,-22},{18,22}}, fileName=
                   "modelica://Modelica_DeviceDrivers/Resources/Images/Icons/Real2FloatArrow.png")}));
@@ -396,7 +392,7 @@ package Packaging
       annotation (Icon(graphics={
             Text(
               extent={{-112,40},{-32,-40}},
-              lineColor={255,127,0},
+              textColor={255,127,0},
               textString="S"),
             Polygon(
               points={{14,0},{-6,20},{-6,10},{-36,10},{-36,-10},{-6,-10},{-6,-20},
@@ -406,7 +402,7 @@ package Packaging
               fillPattern=FillPattern.Solid),
             Text(
               extent={{-100,-40},{100,-80}},
-              lineColor={255,127,0},
+              textColor={255,127,0},
               textString="%data")}));
     end AddString;
 
@@ -443,7 +439,7 @@ package Packaging
       annotation (Icon(graphics={
             Text(
               extent={{30,40},{110,-40}},
-              lineColor={255,0,255},
+              textColor={255,0,255},
               textString="B"),
             Polygon(
               points={{44,0},{24,20},{24,10},{-6,10},{-6,-10},{24,-10},{24,-20},{
@@ -484,7 +480,7 @@ package Packaging
       annotation (Icon(graphics={
             Text(
               extent={{40,40},{120,-40}},
-              lineColor={255,127,0},
+              textColor={255,127,0},
               textString="I"),
             Polygon(
               points={{44,0},{24,20},{24,10},{-6,10},{-6,-10},{24,-10},{24,-20},{
@@ -525,9 +521,7 @@ package Packaging
       annotation (Icon(graphics={
             Text(
               extent={{30,40},{110,-40}},
-              lineColor={0,0,255},
-              fillPattern=FillPattern.Solid,
-              fillColor={0,0,255},
+              textColor={0,0,255},
               textString="R"),
             Polygon(
               points={{44,0},{24,20},{24,10},{-6,10},{-6,-10},{24,-10},{24,-20},{
@@ -569,9 +563,7 @@ package Packaging
       annotation (Icon(graphics={
             Text(
               extent={{30,40},{110,-40}},
-              lineColor={0,0,255},
-              fillPattern=FillPattern.Solid,
-              fillColor={0,0,255},
+              textColor={0,0,255},
               textString="R"),
             Text(
               extent={{-100,-50},{100,-90}},
@@ -604,7 +596,7 @@ package Packaging
       annotation (Icon(graphics={
             Text(
               extent={{38,40},{118,-40}},
-              lineColor={255,127,0},
+              textColor={255,127,0},
               textString="S"),
             Polygon(
               points={{42,0},{22,20},{22,10},{-8,10},{-8,-10},{22,-10},{22,-20},{
@@ -642,12 +634,10 @@ package Packaging
         Icon(graphics={
             Text(
               extent={{-120,40},{-40,-40}},
-              lineColor={255,127,0},
+              textColor={255,127,0},
               textString="I"),
             Text(
               extent={{-100,-50},{100,-90}},
-              fillColor={0,0,127},
-              fillPattern=FillPattern.Solid,
               textString="%bitOffset + %width bits"),
             Bitmap(extent={{-56,-20},{8,19}}, fileName=
                   "Modelica://Modelica_DeviceDrivers/Resources/Images/Icons/Int2BitArrow.png")}),
@@ -687,12 +677,10 @@ package Packaging
                   "Modelica://Modelica_DeviceDrivers/Resources/Images/Icons/Bit2IntArrow.png"),
             Text(
               extent={{-100,-50},{100,-90}},
-              fillColor={0,0,127},
-              fillPattern=FillPattern.Solid,
               textString="%bitOffset + %width bits"),
             Text(
               extent={{40,40},{120,-40}},
-              lineColor={255,127,0},
+              textColor={255,127,0},
               textString="I")}),
         Documentation(info="<html>
 <p>Currently, the unpack block only supports Intel-Endianness (<b>little-endian!</b>).</p>
@@ -731,7 +719,6 @@ package Packaging
               fillColor={255,255,255}),
             Text(
               extent={{-100,-40},{100,-80}},
-              fillPattern=FillPattern.Solid,
               textString="Reset")}));
     end ResetPointer;
 

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/ADC.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/ADC.mo
@@ -32,5 +32,5 @@ annotation(defaultComponentName="adc",
 
 <p>The AVR ADC (analog-to-digital converter) takes as parameters a selection of which voltage reference input to use (<em>voltageReferenceSelect</em>), what voltage this reference voltage has (<em>voltageReference</em>), the <em>analogPort</em> (which analog input to convert to a digital value) and which prescaler to use (<em>prescaler</em>, might be automatically chosen if the used AVR platform had known constants for this). The output is continuously read (at each time step), producing a voltage between 0 and 
 <em>voltageReference</em>.</p>
-</html>"), Icon(graphics = {Text(extent = {{-95, -95}, {95, 95}}, textString = "ADC %analogPort\n0..%voltageReference [V]", fontName = "Arial")}));
+</html>"), Icon(graphics={  Text(extent = {{-95, -95}, {95, 95}}, textString = "ADC %analogPort\n0..%voltageReference [V]", fontName = "Arial")}));
 end ADC;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/DigitalReadBoolean.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/DigitalReadBoolean.mo
@@ -17,5 +17,5 @@ protected
   Functions.Digital.InitRead digital = Functions.Digital.InitRead(port, pin);
 algorithm
   y := Functions.Digital.read(digital, pin);
-annotation(Icon(graphics = {Text(extent = {{-95, -95}, {95, 95}}, textString = "Digital %port%pin", fontName = "Arial")}));
+annotation(Icon(graphics={  Text(extent = {{-95, -95}, {95, 95}}, textString = "Digital %port%pin", fontName = "Arial")}));
 end DigitalReadBoolean;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/DigitalWriteBoolean.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/DigitalWriteBoolean.mo
@@ -17,5 +17,5 @@ protected
   Functions.Digital.InitWrite digital = Functions.Digital.InitWrite(port, pin);
 algorithm
   Functions.Digital.write(digital, pin, u);
-annotation(Icon(graphics = {Text(extent = {{-95, -95}, {95, 95}}, textString = "Digital %port%pin", fontName = "Arial")}));
+annotation(Icon(graphics={  Text(extent = {{-95, -95}, {95, 95}}, textString = "Digital %port%pin", fontName = "Arial")}));
 end DigitalWriteBoolean;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/Microcontroller.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/Microcontroller.mo
@@ -37,5 +37,5 @@ block Microcontroller "Use as an inner block, defining the characteristics of th
   annotation(missingInnerMessage = "Missing inner block for AVR microcontroller (this cannot have default values since the microcontrollers are all different).",
              defaultComponentName="mcu",
              defaultComponentPrefixes="inner",
-             Icon(graphics = {Text(lineColor = {255, 255, 255}, extent = {{-50, -50}, {50, 50}}, textString = "AVR\n%platform", fontName = "Arial", textStyle = {TextStyle.Bold})}, coordinateSystem(initialScale = 0.1)));
+             Icon(graphics={  Text(textColor = {255, 255, 255}, extent = {{-50, -50}, {50, 50}}, textString = "AVR\n%platform", fontName = "Arial", textStyle = {TextStyle.Bold})}, coordinateSystem(initialScale = 0.1)));
 end Microcontroller;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/PWM.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/PWM.mo
@@ -32,5 +32,5 @@ equation
   for i in 1:size(timerNumbers,1) loop
     AVR.Functions.PWM.set(pwm[i], u[i]);
    end for;
-  annotation(defaultComponentName = "pwm", Icon(graphics = {Text(extent = {{-95, -95}, {95, 95}}, textString = "PWM %timer\n%timerNumbers", fontName = "Arial")}));
+  annotation(defaultComponentName = "pwm", Icon(graphics={  Text(extent = {{-95, -95}, {95, 95}}, textString = "PWM %timer\n%timerNumbers", fontName = "Arial")}));
 end PWM;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/SynchronizeRealtime.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/SynchronizeRealtime.mo
@@ -39,5 +39,5 @@ algorithm
   if not initial() then
     Functions.RealTimeSynchronization.wait(sync);
   end if;
-annotation(Icon(graphics = {Text(extent = {{-100, -100}, {100, 100}}, textString = "Real-time:\n%desiredFrequency Hz", fontName = "Arial")}, coordinateSystem(initialScale = 0.1)));
+annotation(Icon(graphics={  Text(extent = {{-100, -100}, {100, 100}}, textString = "Real-time:\n%desiredFrequency Hz", fontName = "Arial")}, coordinateSystem(initialScale = 0.1)));
 end SynchronizeRealtime;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Examples/Arduino/UNO/Blink.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Examples/Arduino/UNO/Blink.mo
@@ -19,7 +19,7 @@ equation
 </html>"),
     Diagram(graphics={        Text(
           extent={{-94,-68},{96,-96}},
-          lineColor={0,0,255},
+          textColor={0,0,255},
           textString=
               "Please see the AVR package documentation before testing the example!")}));
 end Blink;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Examples/SBHS/BoardWithController.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Examples/SBHS/BoardWithController.mo
@@ -18,7 +18,7 @@ equation
   annotation(experiment(Interval=0.008), Diagram(graphics={
                               Text(
           extent={{-94,-74},{96,-102}},
-          lineColor={0,0,255},
+          textColor={0,0,255},
           textString=
               "Please see the AVR package documentation before testing the example!")}));
 end BoardWithController;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Examples/SBHS/Controller.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Examples/SBHS/Controller.mo
@@ -13,7 +13,7 @@ equation
   fan_tmp = integer(max(0,min(fan_real,190)));
   fan = if fan_tmp > 0 then fan_tmp+60 else 0;
   der(ierror) = if ierror > -4 then max(degC-setpoint, -2) else 0;
-annotation(Icon(graphics = {
+annotation(Icon(graphics={
     Text(origin = {-123, 81}, extent = {{-17, 11}, {17, -11}}, textString = "°C", fontName = "Arial"), Text(origin = {-122, -14}, extent = {{-20, 18}, {20, -18}}, textString = "Setpoint", fontName = "Arial"),
     Text(origin = {117, 23}, extent = {{-17, 7}, {17, -7}}, textString = "Fan", fontName = "Arial")}));
 end Controller;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/package.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/package.mo
@@ -71,5 +71,5 @@ make
 make flash
 </pre>
 </html>"),
-Icon(graphics={  Text(origin = {32, -3}, lineColor = {255, 255, 255}, extent = {{-44, 19}, {-20, -13}}, textString = "AVR", fontSize = 70, fontName = "Arial", textStyle = {TextStyle.Bold})}, coordinateSystem(initialScale = 0.1)));
+Icon(graphics={  Text(origin = {32, -3}, textColor = {255, 255, 255}, extent = {{-44, 19}, {-20, -13}}, textString = "AVR", fontSize = 70, fontName = "Arial", textStyle = {TextStyle.Bold})}, coordinateSystem(initialScale = 0.1)));
 end AVR;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/Blocks/Led.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/Blocks/Led.mo
@@ -24,7 +24,7 @@ algorithm
   Functions.Digital.ledOut(digital, u);
 annotation(Icon(graphics={               Text(extent={{-150,144},{150,104}},
             textString="%name"),           Text(extent={{-218,-106},{226,-136}},
-          lineColor={0,0,0},
+          textColor={0,0,0},
           textString="LED: %led"),
         Bitmap(origin = {-5, 1}, extent = {{-25, -65}, {33, 59}}, fileName=
               "modelica://Modelica_DeviceDrivers/Resources/Images/Icons/led-lamp-red-on.png")}));

--- a/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/Blocks/Microcontroller.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/Blocks/Microcontroller.mo
@@ -26,7 +26,7 @@ block Microcontroller "Use as an inner block, defining the characteristics of th
   annotation(missingInnerMessage = "Missing inner block for STM32F4 microcontroller (this cannot have default values since the microcontrollers are all different).",
              defaultComponentName="mcu",
              defaultComponentPrefixes="inner",
-             Icon(graphics={  Text(origin={0,0},    lineColor={255,255,255},     extent={{
+             Icon(graphics={  Text(origin={0,0},    textColor={255,255,255},     extent={{
               -66,-66},{66,66}},                                                                                                                                    fontName=
               "Arial",                                                                                                                                                                  textStyle=
               {TextStyle.Bold},
@@ -34,7 +34,7 @@ block Microcontroller "Use as an inner block, defining the characteristics of th
 %platform"),
         Bitmap(extent={{-128,-112},{128,112}}, fileName=
               "modelica://Modelica_DeviceDrivers/Resources/Images/Icons/microcontroller_scheme.png"),
-                              Text(lineColor={0,0,0},           extent={{-86,
+                              Text(textColor={0,0,0},           extent={{-86,
               -88},{86,74}},                                                                                                    fontName=
               "Arial",                                                                                                                              textStyle=
               {TextStyle.Bold},

--- a/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/Blocks/SynchronizeRealtime.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/Blocks/SynchronizeRealtime.mo
@@ -71,7 +71,7 @@ algorithm
                                                                                   Text(extent={{
               -150,-110},{150,-150}},
           textString="%desiredFrequency Hz",
-          lineColor={0,0,0}),                                                     Text(extent={{
+          textColor={0,0,0}),                                                     Text(extent={{
               -152,144},{148,104}},
             textString="%name")},                                                                                                            coordinateSystem(initialScale = 0.1)));
 end SynchronizeRealtime;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/package.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/STM32F4/package.mo
@@ -123,5 +123,5 @@ openocd -f /usr/share/openocd/scripts/board/stm32f4discovery.cfg
 > reset run
 </pre>
 </html>"),
-Icon(graphics={  Text(origin = {32, -3}, lineColor = {255, 255, 255}, extent = {{-44, 19}, {-20, -13}}, textString = "STM32F4", fontSize = 70, fontName = "Arial", textStyle = {TextStyle.Bold})}, coordinateSystem(initialScale = 0.1)));
+Icon(graphics={  Text(origin = {32, -3}, textColor = {255, 255, 255}, extent = {{-44, 19}, {-20, -13}}, textString = "STM32F4", fontSize = 70, fontName = "Arial", textStyle = {TextStyle.Bold})}, coordinateSystem(initialScale = 0.1)));
 end STM32F4;

--- a/Modelica_DeviceDrivers/Utilities/Icons/BusIcon.mo
+++ b/Modelica_DeviceDrivers/Utilities/Icons/BusIcon.mo
@@ -5,8 +5,6 @@ partial block BusIcon "Icon for a communication bus"
             -100},{100,100}}), graphics={
         Text(
           extent={{-150,102},{150,142}},
-          fillColor={85,85,255},
-          fillPattern=FillPattern.Solid,
           textString="%name"),
         Line(
           points={{-92,0},{92,0}},

--- a/Modelica_DeviceDrivers/Utilities/Icons/ObsoleteIcon.mo
+++ b/Modelica_DeviceDrivers/Utilities/Icons/ObsoleteIcon.mo
@@ -5,6 +5,6 @@ partial model ObsoleteIcon
             -100},{100,100}}), graphics={Rectangle(extent={{-100,100},{100,-100}},
             lineColor={255,0,0}), Text(
           extent={{-100,-92},{100,-130}},
-          lineColor={255,0,0},
+          textColor={255,0,0},
           textString="obsolete")}));
 end ObsoleteIcon;

--- a/Modelica_DeviceDrivers/Utilities/StringExpression.mo
+++ b/Modelica_DeviceDrivers/Utilities/StringExpression.mo
@@ -22,7 +22,7 @@ block StringExpression "Set output to a (time varying) String expression"
         Text(
           extent={{-150,90},{140,50}},
           textString="%name",
-          lineColor={0,0,255})}),
+          textColor={0,0,255})}),
     Documentation(info="<html>
 <p>
 The (time varying) String output of this block can be defined in its

--- a/Modelica_DeviceDrivers/Utilities/package.mo
+++ b/Modelica_DeviceDrivers/Utilities/package.mo
@@ -28,12 +28,12 @@ package Utilities "Collection of utility elements used within the library"
             borderPattern=BorderPattern.Raised),
           Text(
             extent={{-88,16},{82,-14}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="%message"),
           Text(
             extent={{-150,90},{140,50}},
             textString="%name",
-            lineColor={0,0,255})}));
+            textColor={0,0,255})}));
   end TriggeredPrint;
 
   annotation (


### PR DESCRIPTION
Note, that this increases the required Modelica Language version.

In accordance with https://github.com/modelica/ModelicaStandardLibrary/pull/4181.