### PR TITLE
Fix linker errors due to multiply defined symbols

### DIFF
--- a/Modelica_DeviceDrivers/Resources/Include/MDDJoystick.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDJoystick.h
@@ -17,6 +17,7 @@
 #if !defined(ITI_COMP_SIM)
 
 #include "ModelicaUtilities.h"
+#include "../src/include/CompatibilityDefs.h"
 
 #if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__)
 
@@ -26,7 +27,6 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <stdlib.h>
-#include "../src/include/CompatibilityDefs.h"
 
 #pragma comment( lib, "Winmm.lib" )
 
@@ -144,7 +144,7 @@ typedef struct {
     char deviceName[80];
 } MDDJoystick;
 
-void* MDD_joystickConstructor(int iJSID) {
+DllExport void* MDD_joystickConstructor(int iJSID) {
     MDDJoystick* js = (MDDJoystick*) calloc(sizeof(MDDJoystick), 1);
     if (js) {
         js->fd = open("/dev/input/js0", O_RDONLY);
@@ -173,7 +173,7 @@ void* MDD_joystickConstructor(int iJSID) {
     return (void*) js;
 }
 
-void MDD_joystickDestructor(void* jsObj) {
+DllExport void MDD_joystickDestructor(void* jsObj) {
     MDDJoystick* js = (MDDJoystick*) jsObj;
     if (js) {
         free(js->axis);
@@ -182,7 +182,7 @@ void MDD_joystickDestructor(void* jsObj) {
     }
 }
 
-void MDD_joystickGetData(void* jsObj, double * pdAxes, int * piButtons, int * piPOV) {
+DllExport void MDD_joystickGetData(void* jsObj, double * pdAxes, int * piButtons, int * piPOV) {
     int i;
     MDDJoystick* js = (MDDJoystick*) jsObj;
     if (js) {

--- a/Modelica_DeviceDrivers/Resources/Include/MDDJoystick.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDJoystick.h
@@ -17,7 +17,6 @@
 #if !defined(ITI_COMP_SIM)
 
 #include "ModelicaUtilities.h"
-#include "../src/include/CompatibilityDefs.h"
 
 #if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__)
 
@@ -27,6 +26,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <stdlib.h>
+#include "../src/include/CompatibilityDefs.h"
 
 #pragma comment( lib, "Winmm.lib" )
 
@@ -144,7 +144,7 @@ typedef struct {
     char deviceName[80];
 } MDDJoystick;
 
-DllExport void* MDD_joystickConstructor(int iJSID) {
+static void* MDD_joystickConstructor(int iJSID) {
     MDDJoystick* js = (MDDJoystick*) calloc(sizeof(MDDJoystick), 1);
     if (js) {
         js->fd = open("/dev/input/js0", O_RDONLY);
@@ -173,7 +173,7 @@ DllExport void* MDD_joystickConstructor(int iJSID) {
     return (void*) js;
 }
 
-DllExport void MDD_joystickDestructor(void* jsObj) {
+static void MDD_joystickDestructor(void* jsObj) {
     MDDJoystick* js = (MDDJoystick*) jsObj;
     if (js) {
         free(js->axis);
@@ -182,7 +182,7 @@ DllExport void MDD_joystickDestructor(void* jsObj) {
     }
 }
 
-DllExport void MDD_joystickGetData(void* jsObj, double * pdAxes, int * piButtons, int * piPOV) {
+static void MDD_joystickGetData(void* jsObj, double * pdAxes, int * piButtons, int * piPOV) {
     int i;
     MDDJoystick* js = (MDDJoystick*) jsObj;
     if (js) {

--- a/Modelica_DeviceDrivers/Resources/Include/MDDRealtimeSynchronize.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDRealtimeSynchronize.h
@@ -533,12 +533,12 @@ typedef struct {
     int prio; /* dummy */
 } ProcPrio;
 
-void* MDD_ProcessPriorityConstructor(void) {
+DllExport void* MDD_ProcessPriorityConstructor(void) {
     ProcPrio* prio = (ProcPrio*) malloc(sizeof(ProcPrio));
     return (void*) prio;
 }
 
-void MDD_ProcessPriorityDestructor(void* prioObj) {
+DllExport void MDD_ProcessPriorityDestructor(void* prioObj) {
     ProcPrio* prio = (ProcPrio*) prioObj;
     if (prio) {
         free(prio);
@@ -552,7 +552,7 @@ void MDD_ProcessPriorityDestructor(void* prioObj) {
  * @param[in] Process priority external object (dummy)
  * @param[in] priority range: (-2: idle, -1: below normal, 0: normal, 1: high, 2: realtime)
  */
-void MDD_setPriority(void* dummyPrioObj, int priority) {
+DllExport void MDD_setPriority(void* dummyPrioObj, int priority) {
     int ret;
     struct sched_param param;
     errno = 0; /* zero out errno since -1 may be a valid return value for nice(..) and not necessarily indicate error */
@@ -641,7 +641,7 @@ typedef struct {
  *
  * @return RTSync object
  */
-void* MDD_realtimeSynchronizeConstructor() {
+DllExport void* MDD_realtimeSynchronizeConstructor() {
     RTSync* rtSync = (RTSync*) malloc(sizeof(RTSync));
     if (rtSync) {
         int ret = clock_gettime(CLOCK_MONOTONIC, &rtSync->t_start);
@@ -657,7 +657,7 @@ void* MDD_realtimeSynchronizeConstructor() {
     return (void*) rtSync;
 }
 
-void MDD_realtimeSynchronizeDestructor(void* rtSyncObj) {
+DllExport void MDD_realtimeSynchronizeDestructor(void* rtSyncObj) {
     RTSync* rtSync = (RTSync*) rtSyncObj;
     if (rtSync) {
         free(rtSync);
@@ -673,7 +673,7 @@ void MDD_realtimeSynchronizeDestructor(void* rtSyncObj) {
  * @param[out] availableTime time that is left before realtime deadline is reached BUG Windows-Linux implementation differ!
  * @return (s) Time between invocation of this function, i.e. "computing time" in seconds
  */
-double MDD_realtimeSynchronize(void* rtSyncObj, double simTime, int enableScaling, double scaling, double * availableTime) {
+DllExport double MDD_realtimeSynchronize(void* rtSyncObj, double simTime, int enableScaling, double scaling, double * availableTime) {
     double deltaTime = 0.;
     RTSync* rtSync = (RTSync*) rtSyncObj;
     if (rtSync && availableTime) {
@@ -729,7 +729,7 @@ double MDD_realtimeSynchronize(void* rtSyncObj, double simTime, int enableScalin
 * @param[in,out] y subtrahend. Might be modified for performing a carry (however, mathematical sum "y->tv_sec*NSEC_PER_SEC + y->tf_sec" is invariant)
 * @return 1 if the difference is negative, otherwise 0.
 */
-int timespec_subtract (struct timespec *result, struct timespec *x, struct timespec *y)
+DllExport int timespec_subtract (struct timespec *result, struct timespec *x, struct timespec *y)
 {
   /* Perform the carry for the later subtraction by updating y. */
   if (x->tv_nsec < y->tv_nsec) {

--- a/Modelica_DeviceDrivers/Resources/Include/MDDRealtimeSynchronize.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDRealtimeSynchronize.h
@@ -533,12 +533,12 @@ typedef struct {
     int prio; /* dummy */
 } ProcPrio;
 
-DllExport void* MDD_ProcessPriorityConstructor(void) {
+static void* MDD_ProcessPriorityConstructor(void) {
     ProcPrio* prio = (ProcPrio*) malloc(sizeof(ProcPrio));
     return (void*) prio;
 }
 
-DllExport void MDD_ProcessPriorityDestructor(void* prioObj) {
+static void MDD_ProcessPriorityDestructor(void* prioObj) {
     ProcPrio* prio = (ProcPrio*) prioObj;
     if (prio) {
         free(prio);
@@ -552,7 +552,7 @@ DllExport void MDD_ProcessPriorityDestructor(void* prioObj) {
  * @param[in] Process priority external object (dummy)
  * @param[in] priority range: (-2: idle, -1: below normal, 0: normal, 1: high, 2: realtime)
  */
-DllExport void MDD_setPriority(void* dummyPrioObj, int priority) {
+static void MDD_setPriority(void* dummyPrioObj, int priority) {
     int ret;
     struct sched_param param;
     errno = 0; /* zero out errno since -1 may be a valid return value for nice(..) and not necessarily indicate error */
@@ -641,7 +641,7 @@ typedef struct {
  *
  * @return RTSync object
  */
-DllExport void* MDD_realtimeSynchronizeConstructor() {
+static void* MDD_realtimeSynchronizeConstructor() {
     RTSync* rtSync = (RTSync*) malloc(sizeof(RTSync));
     if (rtSync) {
         int ret = clock_gettime(CLOCK_MONOTONIC, &rtSync->t_start);
@@ -657,7 +657,7 @@ DllExport void* MDD_realtimeSynchronizeConstructor() {
     return (void*) rtSync;
 }
 
-DllExport void MDD_realtimeSynchronizeDestructor(void* rtSyncObj) {
+static void MDD_realtimeSynchronizeDestructor(void* rtSyncObj) {
     RTSync* rtSync = (RTSync*) rtSyncObj;
     if (rtSync) {
         free(rtSync);
@@ -673,7 +673,7 @@ DllExport void MDD_realtimeSynchronizeDestructor(void* rtSyncObj) {
  * @param[out] availableTime time that is left before realtime deadline is reached BUG Windows-Linux implementation differ!
  * @return (s) Time between invocation of this function, i.e. "computing time" in seconds
  */
-DllExport double MDD_realtimeSynchronize(void* rtSyncObj, double simTime, int enableScaling, double scaling, double * availableTime) {
+static double MDD_realtimeSynchronize(void* rtSyncObj, double simTime, int enableScaling, double scaling, double * availableTime) {
     double deltaTime = 0.;
     RTSync* rtSync = (RTSync*) rtSyncObj;
     if (rtSync && availableTime) {
@@ -729,7 +729,7 @@ DllExport double MDD_realtimeSynchronize(void* rtSyncObj, double simTime, int en
 * @param[in,out] y subtrahend. Might be modified for performing a carry (however, mathematical sum "y->tv_sec*NSEC_PER_SEC + y->tf_sec" is invariant)
 * @return 1 if the difference is negative, otherwise 0.
 */
-DllExport int timespec_subtract (struct timespec *result, struct timespec *x, struct timespec *y)
+static int timespec_subtract (struct timespec *result, struct timespec *x, struct timespec *y)
 {
   /* Perform the carry for the later subtraction by updating y. */
   if (x->tv_nsec < y->tv_nsec) {
@@ -753,7 +753,7 @@ DllExport int timespec_subtract (struct timespec *result, struct timespec *x, st
 }
 
 /** DELETE as soon as MDD_RTSyncSynchronize has been successfully tested ! * FIXME 2019-05-23: Needs careful review and revision, since coded quickly without much thought. */
-DllExport double MDD_sampledRealtimeSynchronize(void* rtSyncObj, double simTime, double lastSimTime, double scaling, double * wallClockTime, double * remainingTime) {
+static double MDD_sampledRealtimeSynchronize(void* rtSyncObj, double simTime, double lastSimTime, double scaling, double * wallClockTime, double * remainingTime) {
     double calculationTime = 0, samplingPeriod = 0, timeLeft = 0;
 
     double deltaTime = 0;
@@ -824,7 +824,7 @@ DllExport double MDD_sampledRealtimeSynchronize(void* rtSyncObj, double simTime,
     return deltaTime;
 }
 
-DllExport double MDD_getTimeMS(double dummy) {
+static double MDD_getTimeMS(double dummy) {
     struct timespec ts;
     int ret = clock_gettime(CLOCK_MONOTONIC, &ts);
     if (ret) {
@@ -854,7 +854,7 @@ typedef struct {
 * @param[in] shouldCatchupTime (boolean flag) if catchupTime != 0 then try to catch up delays from missed dead-lines by progressing faster than real-time, otherwise do not.
 * @return MDD_RTSync object
 */
-DllExport void* MDD_RTSyncConstructor(double startSimTime, int shouldCatchupTime) {
+static void* MDD_RTSyncConstructor(double startSimTime, int shouldCatchupTime) {
     int ret;
     MDD_RTSync* rtSync = (MDD_RTSync*)malloc(sizeof(MDD_RTSync));
     if (rtSync) {
@@ -874,7 +874,7 @@ DllExport void* MDD_RTSyncConstructor(double startSimTime, int shouldCatchupTime
 }
 
 /** MDD_RTSync destructor. */
-DllExport void MDD_RTSyncDestructor(void* rtSyncObj) {
+static void MDD_RTSyncDestructor(void* rtSyncObj) {
     MDD_RTSync* rtSync = (MDD_RTSync*)rtSyncObj;
     if (rtSync) {
         free(rtSync);
@@ -892,7 +892,7 @@ DllExport void MDD_RTSyncDestructor(void* rtSyncObj) {
 * @param[out] computingTime (s) wall clock time between invocations of this function, i.e. "computing time" in seconds
 * @param[out] lastSimTime (s) simulation time at the previous invocation of this function, the simulation start time at the first function invocation
 */
-DllExport void MDD_RTSyncSynchronize(void * rtSyncObj, double simTime, double scaling, double * wallClockTime, double * remainingTime, double * computingTime, double * lastSimTime) {
+static void MDD_RTSyncSynchronize(void * rtSyncObj, double simTime, double scaling, double * wallClockTime, double * remainingTime, double * computingTime, double * lastSimTime) {
     MDD_RTSync* rtSync = (MDD_RTSync*)rtSyncObj;
     struct timespec t_now;
     struct timespec t_elapsed;

--- a/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
+++ b/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
@@ -43,7 +43,7 @@
 #  define DllExport __declspec( dllexport )
 # else
 #  define DllImport
-#  define DllExport
+#  define DllExport static
 # endif /* _MSC_VER */
 #else
 # define DllImport

--- a/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
+++ b/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
@@ -43,7 +43,7 @@
 #  define DllExport __declspec( dllexport )
 # else
 #  define DllImport
-#  define DllExport static
+#  define DllExport
 # endif /* _MSC_VER */
 #else
 # define DllImport


### PR DESCRIPTION
This fixes problems on Linux when spreading out the generated code for external functions over multiple translation units.

In general, I think the more clean way of fixing the problem would be to have each external C function definition be included (by means of `Include` annotation) by at most one Modelica external function, but the "trick" used here of making the definitions `static` is less invasive.
