### PR TITLE
Declare array inputs of external C functions const (introduced in Modelica 3.5)

### DIFF
--- a/Modelica_DeviceDrivers/Resources/Include/MDDMinimalSerialPackager.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDMinimalSerialPackager.h
@@ -38,7 +38,7 @@ void MSP_destroyPackager(int p_MSP_PackagerData) {
     free(MSP_PackagerData);
 
 }
-void MSP_addReal(int p_MSP_PackagerData, double * u, int n) {
+void MSP_addReal(int p_MSP_PackagerData, const double * u, int n) {
     struct MSP_PackagerData * MSP_PackagerData =
         (struct MSP_PackagerData *) p_MSP_PackagerData;
     int typeSize = sizeof(double);
@@ -54,7 +54,7 @@ void MSP_addReal(int p_MSP_PackagerData, double * u, int n) {
 
 }
 
-void MSP_addInteger(int p_MSP_PackagerData, int * u, int n) {
+void MSP_addInteger(int p_MSP_PackagerData, const int * u, int n) {
     struct MSP_PackagerData * MSP_PackagerData =
         (struct MSP_PackagerData *) p_MSP_PackagerData;
     int typeSize = sizeof(int);
@@ -70,7 +70,7 @@ void MSP_addInteger(int p_MSP_PackagerData, int * u, int n) {
 
 }
 
-void MSP_addString(int p_MSP_PackagerData, char * u) {
+void MSP_addString(int p_MSP_PackagerData, const char * u) {
     struct MSP_PackagerData * MSP_PackagerData =
         (struct MSP_PackagerData *) p_MSP_PackagerData;
     int typeSize = sizeof(char);

--- a/Modelica_DeviceDrivers/Resources/Include/MDDSerialPackager.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDSerialPackager.h
@@ -240,7 +240,7 @@ DllExport void MDD_SerialPackagerAlignToByteBoundary(SerialPackager* p_package) 
  * @param[in] n number of values in u
  * @param[in] endian byte order
  */
-DllExport void MDD_SerialPackagerAddInteger(void* p_package, int * u, size_t n, int endian) {
+DllExport void MDD_SerialPackagerAddInteger(void* p_package, const int * u, size_t n, int endian) {
     SerialPackager* pkg = (SerialPackager*) p_package;
     if (pkg->bitOffset != 0) {
         MDD_SerialPackagerAlignToByteBoundary(pkg);
@@ -304,7 +304,7 @@ DllExport void MDD_SerialPackagerGetInteger(void* p_package, int * y, int n, int
  * @param[in] n number of values in u
  * @param[in] endian byte order
  */
-DllExport void MDD_SerialPackagerAddDouble(void* p_package, double * u, size_t n, int endian) {
+DllExport void MDD_SerialPackagerAddDouble(void* p_package, const double * u, size_t n, int endian) {
     SerialPackager* pkg = (SerialPackager*) p_package;
     if (pkg->bitOffset != 0) {
         MDD_SerialPackagerAlignToByteBoundary(pkg);
@@ -366,7 +366,7 @@ DllExport void MDD_SerialPackagerGetDouble(void* p_package, double * y, int n, i
  * @param[in] n number of values in u
  * @param[in] endian byte order
  */
-DllExport void MDD_SerialPackagerAddDoubleAsFloat(void* p_package, double * u, size_t n, int endian) {
+DllExport void MDD_SerialPackagerAddDoubleAsFloat(void* p_package, const double * u, size_t n, int endian) {
     SerialPackager* pkg = (SerialPackager*) p_package;
     if (pkg->bitOffset != 0) {
         MDD_SerialPackagerAlignToByteBoundary(pkg);

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Main features:
   * Support for a universal packaging concept to pack Modelica variables in a graphical and convenient way into a bit vector and transport such a bit vector via UDP, TCP/IP, LCM, MQTT, serial I/O or shared memory (CAN support is prototypical available).
   * Support of the Linux control and measurement device interface for digital and analog I/O (Comedi interface).
 
-All device drivers are made available via external Modelica functions. Furthermore, high level interfaces on these functions are provided via Modelica blocks. The first interface uses Modelica 3.2 functionality only (when-clauses and sample-operator).
+All device drivers are made available via external Modelica functions. Furthermore, high level interfaces on these functions are provided via Modelica blocks. The first interface uses Modelica 3.5 functionality only (when-clauses and sample-operator).
 The second interface uses the synchronous language elements introduced in Modelica 3.3 and is based on clocks.
 
 ![BlockOverview](screenshot.png)


### PR DESCRIPTION
I hope I caught them all.