### PR TITLE
Delete Modelica_DeviceDrivers/libraryinfo.mos

### DIFF
--- a/Modelica_DeviceDrivers/libraryinfo.mos
+++ b/Modelica_DeviceDrivers/libraryinfo.mos
@@ -1,9 +1,0 @@
-LibraryInfoMenuCommand(
-  category="libraries",
-  text="Modelica Device Drivers",
-  reference="Modelica_DeviceDrivers",
-  version="2.1.1",
-  isModel=true,
-  description="Modelica Device Drivers library (version 2.1.1)",
-  ModelicaVersion=">=4.0.0",
-  pos=106)


### PR DESCRIPTION
This is a Dymola-specific file that we can manage as part of the Dymola distribution, there is no need to pollute the MA GitHub repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the library registration metadata for "Modelica Device Drivers" from the application. This may affect how the library appears in menus or library management interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->