### PR TITLE
Fix process priority reset on Linux (#44)

### DIFF
--- a/Modelica_DeviceDrivers/Resources/Include/MDDRealtimeSynchronize.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDRealtimeSynchronize.h
@@ -548,11 +548,14 @@ static void* MDD_ProcessPriorityConstructor(void) {
         }
 
         /* Get original scheduling parameters for realtime restoration */
+        errno = 0;
         prio->originalSchedPolicy = sched_getscheduler(0);
+        if (prio->originalSchedPolicy == -1) {
+            ModelicaError("MDDRealtimeSynchronize.h: sched_getscheduler failed in constructor\n");
+        }
         if (sched_getparam(0, &prio->originalSchedParam) != 0) {
             ModelicaError("MDDRealtimeSynchronize.h: sched_getparam failed in constructor\n");
         }
-
         prio->isSet = 0;           /* Priority not set yet */
         prio->useRealtime = 0;     /* Not using realtime */
 


### PR DESCRIPTION
This implementation now mirrors the behavior of the Windows version by properly storing and restoring the original priority settings when the destructor is called.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced Linux process priority control with mapped niceness levels plus a true real-time scheduling path.
  - Tracks and preserves the original scheduling and priority state so it can be restored reliably.
  - Informative status messages when applying or restoring priority modes.

- Bug Fixes
  - Restores previous priority state before applying new settings to avoid conflicts.
  - Fixes cases where real-time or niceness changes could linger.
  - Improved error handling for priority and scheduling operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->